### PR TITLE
Add muon scale/smearing module

### DIFF
--- a/BuildFile.xml
+++ b/BuildFile.xml
@@ -1,0 +1,7 @@
+<use name="root"/>
+<use name="rootrflx"/>
+<use name="correctionlib"/>
+
+<export>
+  <lib   name="1"/>
+</export>

--- a/python/modules/muonScaleRes.py
+++ b/python/modules/muonScaleRes.py
@@ -1,0 +1,88 @@
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
+import os
+import numpy as np
+from math import pi
+from ROOT import MuonScaRe
+
+class muonScaleRes(Module):
+    def __init__(self, json, is_mc, overwritePt=False, maxPt=200.):
+        """Add branches for muon scale and resolution corrections.
+        Parameters:
+            json: full path of json file
+            is_mc: True for MC (smear pt+add uncertainties), False for data (scale pt)
+            overwritePt: replace value in the pt branch, and store the old one as "uncorrected_pt"
+            maxPt: # Do not correct for muons above this pT (200 GeV according to current recipe, 8/24)
+        """
+
+        self.is_mc = is_mc
+        self.overwritePt = overwritePt
+        self.maxPt = maxPt
+        
+        self.corrModule = MuonScaRe(json)
+
+
+    def getPtCorr(self, muon, var = "nom") :
+        if muon.pt > self.maxPt : 
+            return muon.pt
+        isData = int(not self.is_mc)
+        scale_corr = self.corrModule.pt_scale(isData, muon.pt, muon.eta, muon.phi, muon.charge, var)
+        pt_corr = scale_corr
+
+        if self.is_mc:
+            smear_corr = self.corrModule.pt_resol(scale_corr, muon.eta, muon.nTrackerLayers, var)
+            pt_corr = smear_corr
+
+        return pt_corr
+
+
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        self.out = wrappedOutputTree
+        if self.overwritePt :
+            self.out.branch("Muon_pt", "F", lenVar="nMuon")
+            self.out.branch("Muon_uncorrected_pt", "F", lenVar="nMuon")
+        else:
+            self.out.branch("Muon_corrected_pt", "F", lenVar="nMuon")
+        if self.is_mc:
+            self.out.branch("Muon_syst_pt", "F", lenVar="nMuon")
+            self.out.branch("Muon_stat_pt", "F", lenVar="nMuon")
+
+
+    def analyze(self, event):
+        if event.nMuon == 0 :
+            return True
+
+        muons = Collection(event, "Muon")
+
+        pt_corr = [0.]*len(muons)
+        if self.is_mc:
+            pt_syst = [0.]*len(muons)
+            pt_stat = [0.]*len(muons)
+                
+        for imu, muon in enumerate(muons):
+            # Set up a deterministic random seed.
+            # The seed is unique by event and muon.
+            # A fixed entropy value is also included to decorrelate different modules doing similar things.
+            seedSeq = np.random.SeedSequence([event.luminosityBlock, event.event, int(abs((muon.phi/pi*100.)%1)*1e10), 351740215])
+            self.corrModule.setSeed(int(seedSeq.generate_state(1,np.uint64)[0]))
+
+            pt_corr[imu] = self.getPtCorr(muon, "nom")
+
+            if self.is_mc:
+                # TODO: Check. Are we assuming up=dn?
+                pt_syst[imu] = self.getPtCorr(muon, "syst")
+                pt_stat[imu] = self.getPtCorr(muon, "stat")
+
+        if self.overwritePt :
+            pt_uncorr = list(mu.pt for mu in muons)
+            self.out.fillBranch("Muon_uncorrected_pt", pt_uncorr)
+            self.out.fillBranch("Muon_pt", pt_corr)
+        else :
+            self.out.fillBranch("Muon_corrected_pt", pt_corr)
+
+        if self.is_mc:
+            self.out.fillBranch("Muon_syst_pt", pt_syst)
+            self.out.fillBranch("Muon_stat_pt", pt_stat)
+
+        return True
+

--- a/src/MuonScaRe.cc
+++ b/src/MuonScaRe.cc
@@ -1,0 +1,160 @@
+/*  
+ * Run3 Muon correction module, imported from:
+ * https://gitlab.cern.ch/cms-muonPOG/muonscarekit/-/blob/82cc2a4ec97c93ee4e791398f4bc5fbe24859bb3/scripts/MuonScaRe.cc
+ * with the following modifications:
+ * -encapsulated in a class so that the correctionSet and RNG are kept 
+ *  internally
+ * -add function to optionally set the RNG seed, so that the user can implement 
+ *  deterministic pseudo-random smearing. If desired, a proper seed should 
+ *  be passed once for each muon before calling pt_resol the first time for 
+ *  that mu.
+ *  Note: setting the seed is left to the user since in the current 
+ *  implementation get_rndm, which normally getsis called 3 times for each mu 
+ *  (for var = norm, syst, stat), does not have access to enough sources of 
+ *  entropy to create a decent seed internally.
+ * -avoid trivial string manipulations in pt_scale
+ */
+
+#include <boost/math/special_functions/erf.hpp>
+#include <string>
+#include <ZZAnalysis/AnalysisStep/interface/MuonScaRe.h>
+
+using namespace std;
+
+MuonScaRe::MuonScaRe(string json) : cset(correction::CorrectionSet::from_file(json)){}
+ 
+
+struct CrystalBall{
+    double pi=3.14159;
+    double sqrtPiOver2=sqrt(pi/2.0);
+    double sqrt2=sqrt(2.0);
+    double m;
+    double s;
+    double a;
+    double n;
+    double B;
+    double C;
+    double D;
+    double N;
+    double NA;
+    double Ns;
+    double NC;
+    double F;
+    double G;
+    double k;
+    double cdfMa;
+    double cdfPa;
+CrystalBall():m(0),s(1),a(10),n(10){
+    init();
+}
+CrystalBall(double mean, double sigma, double alpha, double n)
+    :m(mean),s(sigma),a(alpha),n(n){
+    init();
+}
+void init(){
+    double fa = fabs(a);
+    double ex = exp(-fa*fa/2);
+    double A  = pow(n/fa, n) * ex;
+    double C1 = n/fa/(n-1) * ex; 
+    double D1 = 2 * sqrtPiOver2 * erf(fa/sqrt2);
+    B = n/fa-fa;
+    C = (D1+2*C1)/C1;   
+    D = (D1+2*C1)/2;   
+    N = 1.0/s/(D1+2*C1); 
+    k = 1.0/(n-1);  
+    NA = N*A;       
+    Ns = N*s;       
+    NC = Ns*C1;     
+    F = 1-fa*fa/n; 
+    G = s*n/fa;    
+    cdfMa = cdf(m-a*s);
+    cdfPa = cdf(m+a*s);
+}
+double pdf(double x) const{ 
+    double d=(x-m)/s;
+    if(d<-a) return NA*pow(B-d, -n);
+    if(d>a) return NA*pow(B+d, -n);
+    return N*exp(-d*d/2);
+}
+double pdf(double x, double ks, double dm) const{ 
+    double d=(x-m-dm)/(s*ks);
+    if(d<-a) return NA/ks*pow(B-d, -n);
+    if(d>a) return NA/ks*pow(B+d, -n);
+    return N/ks*exp(-d*d/2);
+
+}
+double cdf(double x) const{
+    double d = (x-m)/s;
+    if(d<-a) return NC / pow(F-s*d/G, n-1);
+    if(d>a) return NC * (C - pow(F+s*d/G, 1-n) );
+    return Ns * (D - sqrtPiOver2 * erf(-d/sqrt2));
+}
+double invcdf(double u) const{
+    if(u<cdfMa) return m + G*(F - pow(NC/u, k));
+    if(u>cdfPa) return m - G*(F - pow(C-u/NC, -k) );
+    return m - sqrt2 * s * boost::math::erf_inv((D - u/Ns )/sqrtPiOver2);
+}
+};
+
+double MuonScaRe::get_rndm(double eta, float nL) {
+
+    // obtain parameters from correctionlib
+    double mean = cset->at("cb_params")->evaluate({abs(eta), nL, 0});
+    double sigma = cset->at("cb_params")->evaluate({abs(eta), nL, 1});
+    double n = cset->at("cb_params")->evaluate({abs(eta), nL, 2});
+    double alpha = cset->at("cb_params")->evaluate({abs(eta), nL, 3});
+    
+    // instantiate CB and get random number following the CB
+    CrystalBall cb(mean, sigma, alpha, n);
+    return cb.invcdf(rng.Rndm());
+}
+
+
+double MuonScaRe::get_std(double pt, double eta, float nL) {
+
+    // obtain paramters from correctionlib
+    double param_0 = cset->at("poly_params")->evaluate({abs(eta), nL, 0});
+    double param_1 = cset->at("poly_params")->evaluate({abs(eta), nL, 1});
+    double param_2 = cset->at("poly_params")->evaluate({abs(eta), nL, 2});
+
+    // calculate value and return max(0, val)
+    double sigma = param_0 + param_1 * pt + param_2 * pt*pt;
+    if (sigma < 0) sigma = 0;
+    return sigma; 
+}
+
+
+double MuonScaRe::get_k(double eta, string var) {
+
+    // obtain parameters from correctionlib
+    double k_data = cset->at("k_data")->evaluate({abs(eta), var});
+    double k_mc = cset->at("k_mc")->evaluate({abs(eta), var});
+
+    // calculate residual smearing factor
+    // return 0 if smearing in MC already larger than in data
+    double k = 0;
+    if (k_mc < k_data) k = sqrt(k_data*k_data - k_mc*k_mc);
+    return k;
+}
+
+
+double MuonScaRe::pt_resol(double pt, double eta, float nL, string var) {
+
+    // load correction values
+    double rndm = (double) get_rndm(eta, nL);
+    double std = (double) get_std(pt, eta, nL);
+    double k = (double) get_k(eta, var);
+
+    // calculate corrected value and return original value if a parameter is nan
+    double ptc = pt * ( 1 + k * std * rndm);
+    if (isnan(ptc)) ptc = pt;
+    return ptc;
+}
+
+
+double MuonScaRe::pt_scale(bool is_data, double pt, double eta, double phi, int charge, string var) {
+  
+    double a = cset->at(is_data?"a_data":"a_mc")->evaluate({eta, phi, var});
+    double m = cset->at(is_data?"m_data":"m_mc")->evaluate({eta, phi, var});
+    return 1. / (m/pt + charge * a);
+}

--- a/src/classes.h
+++ b/src/classes.h
@@ -1,0 +1,1 @@
+#include <ZZAnalysis/AnalysisStep/interface/MuonScaRe.h>

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -1,0 +1,3 @@
+<lcgdict>
+  <class name="MuonScaRe"/>
+</lcgdict>

--- a/test/example_muonSS.py
+++ b/test/example_muonSS.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+###
+# This is an example of configuring and using the muon scale/smearing module.
+###
+from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import PostProcessor
+from PhysicsTools.NATModules.modules.muonScaleRes import *
+
+# Set up the correction module.
+# json files are not included in the central cvmfs area at the time of release.
+# see https://gitlab.cern.ch/cms-muonPOG/muonscarekit/-/tree/master/corrections for details.
+muSS = muonScaleRes("2022EE_schemaV2.json.gz", overwritePt=True, is_mc=True)
+
+# Settings for post-processor
+from argparse import ArgumentParser
+parser = ArgumentParser(description="Process nanoAOD files and add branches",epilog="Good luck!")
+parser.add_argument('-i', '--infiles', nargs='+')
+parser.add_argument('-m', '--maxevts', type=int, default=10000) # limit number of events (per file) for testing
+args = parser.parse_args()
+branchsel = None
+fnames = args.infiles or [
+  "root://cms-xrd-global.cern.ch//store/mc/Run3Summer22EENanoAODv12/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v6-v2/2540000/25c8f5ff-9de0-4a0c-9e2f-757332ad392f.root"
+]
+
+# Process nanoAOD file
+p = PostProcessor(".", fnames, "nMuon>=2 && Muon_pt>5",branchsel,
+                  [muSS], maxEntries=args.maxevts, postfix="_MuonSS",
+                  outputbranchsel=branchsel, provenance=True,
+                  prefetch=True, longTermCache=True)
+p.run()


### PR DESCRIPTION
Add a module for muon scale/smearing corrections, based on the code and jsons from: https://gitlab.cern.ch/cms-muonPOG/muonscarekit/ .
See test/example_muonSS.py for a usage example.
