### PR TITLE
Add JES uncertainties (Total) + fix JetVeto Map condition

### DIFF
--- a/python/modules/jetVetoMap.py
+++ b/python/modules/jetVetoMap.py
@@ -42,7 +42,7 @@ class jetVMAP(Module):
 
 
         for i, jet in enumerate(jets):
-            if (jet.pt> 15 and (jet.jetId ==2 or jet.jetId ==6) and jet.chEmEF < 0.9 and jet.neEmEF <0.9 and jet.muonIdx1 == -1 and jet.muonIdx2 == -1):
+            if (jet.pt> 15 and (jet.jetId ==2 or jet.jetId ==6) and (jet.chEmEF + jet.neEmEF)<0.9 and jet.muonIdx1 == -1 and jet.muonIdx2 == -1):
 
                 # Correct phi and evaluate veto map
                 phi = self.fixPhi(jet.phi)


### PR DESCRIPTION
**PR Description**
- Added **Total** Jet Energy scale uncertanties (JES) treatment according to the latest JME recommendations (https://cms-talk.web.cern.ch/t/question-about-computing-and-applying-jes-uncertainties/105371/2)

- Updated the JetVeto map condition to ensure that the sum of the charged and neutral electromagnetic energy fractions for each jet is less than 0.9. The corrected condition is now properly implemented as (jet.chEmEF + jet.neEmEF) < 0.9 (https://cms-talk.web.cern.ch/t/jet-veto-maps-for-run3/57850/5)