### PR TITLE
Update jetCorr.py to handle new version of JEC corrections

### DIFF
--- a/python/modules/jetCorr.py
+++ b/python/modules/jetCorr.py
@@ -13,7 +13,7 @@ import numpy as np
 import correctionlib
 
 class jetJERC(Module):
-    def __init__(self, json_JERC, json_JERsmear, L1Key=None, L2Key=None, L3Key=None, L2L3Key=None, scaleTotalKey=None,smearKey=None, JERKey=None, JERsfKey=None, overwritePt=False, usePhiDependentJEC=False):
+    def __init__(self, json_JERC, json_JERsmear, L1Key=None, L2Key=None, L3Key=None, L2L3Key=None, scaleTotalKey=None,smearKey=None, JERKey=None, JERsfKey=None, overwritePt=False, usePhiDependentJEC=False, useRunDependentJEC=False):
         """Correct jets following recommendations of JME POG.
         Parameters:
             json_JERC: full path of json file with JERC corrections
@@ -30,6 +30,7 @@ class jetJERC(Module):
         """
         self.overwritePt = overwritePt
         self.usePhiDependentJEC = usePhiDependentJEC
+        self.useRunDependentJEC = useRunDependentJEC
 
         self.evaluator_JERC = correctionlib.CorrectionSet.from_file(json_JERC)
         self.evaluator_jer = correctionlib.CorrectionSet.from_file(json_JERsmear)
@@ -120,10 +121,12 @@ class jetJERC(Module):
                 pt_L2 = pt_L1 * self.evaluator_L2.evaluate(jet.eta, pt_L1)
 
             pt_L3 = pt_L2 * self.evaluator_L3.evaluate(jet.eta, pt_L2)
-            if self.is_mc:
-                pt_JEC = pt_L3 * self.evaluator_L2L3.evaluate(jet.eta, pt_L3)
-            else:
+
+            if self.useRunDependentJEC:
                 pt_JEC = pt_L3 * self.evaluator_L2L3.evaluate(float(event.run), jet.eta, pt_L3)
+            else:
+                pt_JEC = pt_L3 * self.evaluator_L2L3.evaluate(jet.eta, pt_L3)
+
             JEC = pt_JEC / pt_raw
             mass_JEC = mass_raw * JEC
 

--- a/test/example_jetCorr.py
+++ b/test/example_jetCorr.py
@@ -15,8 +15,10 @@ smearKey = "JERSmear"
 JERKey = "Summer22_22Sep2023_JRV1_MC_PtResolution_AK4PFPuppi"
 JERsfKey = "Summer22_22Sep2023_JRV1_MC_ScaleFactor_AK4PFPuppi"
 overwritePt = True
+usePhiDependentJEC = False
+useRunDependentJEC = False
 
-jetCorrected = jetJERC(json_JERC, json_JERsmear, L1Key, L2Key, L3Key, L2L3Key, scaleTotalKey, smearKey, JERKey, JERsfKey, overwritePt)
+jetCorrected = jetJERC(json_JERC, json_JERsmear, L1Key, L2Key, L3Key, L2L3Key, scaleTotalKey, smearKey, JERKey, JERsfKey, overwritePt, usePhiDependentJEC, useRunDependentJEC)
 
 # Settings for post-processor
 from argparse import ArgumentParser


### PR DESCRIPTION
This PR introduces support for the new version of JEC corrections for 2023 data-taking period only.

Details about the updated JSON files can be found here: https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/merge_requests/118
Notably, the DATA tags in this release are run-dependent — the correction now requires the run number as an additional real-valued input. The appropriate set of JECs will be automatically selected during evaluation based on this value.