### PR TITLE
Apply Scaling method for jets around Horns region + Update Muons Scale and Smearing treatment 

### DIFF
--- a/interface/MuonScaRe.h
+++ b/interface/MuonScaRe.h
@@ -11,9 +11,13 @@ class MuonScaRe {
 public:
   MuonScaRe(std::string json);
 
-  double pt_resol(double pt, double eta, float nL, std::string var);
+  double pt_resol(double pt, double eta, float nL);
   
-  double pt_scale(bool is_data, double pt, double eta, double phi, int charge, std::string var);
+  double pt_scale(bool is_data, double pt, double eta, double phi, int charge);
+
+  double pt_resol_var(double pt_woresol, double pt_wresol, double eta, std::string updn);
+
+  double pt_scale_var(double pt, double eta, double phi, int charge, std::string updn);
 
   // A per-muon seed can be optionally set to achieve deterministic random
   // smearing. 

--- a/python/modules/muonScaleRes.py
+++ b/python/modules/muonScaleRes.py
@@ -6,7 +6,7 @@ from math import pi
 from ROOT import MuonScaRe
 
 class muonScaleRes(Module):
-    def __init__(self, json, is_mc, overwritePt=False, maxPt=200.):
+    def __init__(self, json, is_mc, overwritePt=False, maxPt=200., minPt=26.):
         """Add branches for muon scale and resolution corrections.
         Parameters:
             json: full path of json file
@@ -18,12 +18,13 @@ class muonScaleRes(Module):
         self.is_mc = is_mc
         self.overwritePt = overwritePt
         self.maxPt = maxPt
+        self.minPt = minPt
         
         self.corrModule = MuonScaRe(json)
 
 
     def getPtCorr(self, muon):
-        if muon.pt > self.maxPt:
+        if muon.pt < self.minPt or muon.pt > self.maxPt:
             return muon.pt, muon.pt  # no correction above maxPt
 
         isData = int(not self.is_mc)
@@ -43,14 +44,14 @@ class muonScaleRes(Module):
 
     def getPtVarRes(self, muon, pt_corr_scale, pt_corr_scaleres, updn):
         """Handle Resolution variations"""
-        if muon.pt > self.maxPt:
+        if muon.pt < self.minPt or muon.pt > self.maxPt:
             return muon.pt
         
         return self.corrModule.pt_resol_var(pt_corr_scale, pt_corr_scaleres, muon.eta, updn)
 
     def getPtVarScale(self, muon, pt_corr_scaleres, updn):
         """Handle Scale variations"""
-        if muon.pt > self.maxPt:
+        if muon.pt < self.minPt or muon.pt > self.maxPt:
             return muon.pt
 
         return self.corrModule.pt_scale_var(pt_corr_scaleres, muon.eta, muon.phi, muon.charge, updn)


### PR DESCRIPTION
- This PR applies the scaling method for JER the eta region 2.5 < |eta| < 3.0 where the Horns issue is present, for more details see https://gitlab.cern.ch/cms-jetmet/coordination/coordination/-/issues/113
- In the attached plots for the 2022 preEE data-taking period, you can observe:
Plot 1: The result of applying the hybrid method uniformly, which exhibits prominent "Horns".
Plot 2: The outcome when the scaling method is applied only in the problematic eta region, reducing the “Horns” effect. 
Plots are performed in the Z Control region with Jet cleaning applied, MC is normalised to Data for both plots
<img width="762" alt="leadEta_preEE2022_Hybrid" src="https://github.com/user-attachments/assets/29082450-9b8a-4fcc-b686-9248b430e806" />
<img width="698" alt="leadEta_preEE2022_Scaling" src="https://github.com/user-attachments/assets/e5b58f9e-706d-441d-91f6-aae02fe30e6c" />

