### PR TITLE
Updates for 2024 ele SS + fixes

### DIFF
--- a/python/modules/eleScaleRes.py
+++ b/python/modules/eleScaleRes.py
@@ -11,12 +11,12 @@ import correctionlib
 from math import pi
 
 class eleScaleRes(Module):
-    def __init__(self, json, scaleKey=None, smearKey=None, overwritePt=False, EtDependent=False):
+    def __init__(self, json, scaleKey=None, smearKey=None, overwritePt=False):
         """Add branches for electron scale and resolution corrections.
         Parameters:
             json: full path of json file
             scaleKey: key for the scale correction for data and scale uncertainty in MC
-            smearKey: key for the MC smearing correction (None for Data)
+            smearKey: key for the MC smearing correction (None for Data; any other value implies MC)
             overwritePt: replace value in the pt branch, and store the old one as "uncorrected_pt"
         """
         if (scaleKey == None and smearKey == None) :
@@ -24,23 +24,57 @@ class eleScaleRes(Module):
         if (smearKey != None and scaleKey == None ) :
             raise ValueError("eleScaleResProducer: scaleKey is required when smearKey is set (ie in MC)")
         self.overwritePt = overwritePt
-        self.EtDependent = EtDependent
         
         evaluator = correctionlib.CorrectionSet.from_file(json)
         self.evaluator_scale = None
         self.evaluator_smear = None
         self.is_mc = False
 
-        if self.EtDependent :
-            if scaleKey != None :
+        if scaleKey != None :
+            if scaleKey in evaluator.compound : # Et-dependent corrections. We keep track of this only as a cross-check.
+                self.EtDependent = True
                 self.evaluator_scale = evaluator.compound[scaleKey]
-        else:
-            if scaleKey != None :
+            else : # "Standard" corrections
+                self.EtDependent = False 
                 self.evaluator_scale = evaluator[scaleKey]
 
         if smearKey != None :
             self.evaluator_smear = evaluator[smearKey]
             self.is_mc = True
+
+        # Detect which set of variables should be passed for scale (data) and smearing+uncertainties (MC)
+        self.getSmear = None;
+        self.getSmearUnc = None;
+        self.getScale = None;
+        self.getScaleUnc = None;
+        varlist = [i.name for i in self.evaluator_smear.inputs]
+        if varlist == ['valtype', 'eta', 'r9'] and not self.EtDependent : # Standard
+            # Note: SC eta is available as ele.superclusterEta starting from nanoAODv15. It needs to be recomputed to support older versions.
+            self.getSmear    = lambda ele: self.evaluator_smear.evaluate("rho",     ele.eta+ele.deltaEtaSC, ele.r9)
+            self.getSmearUnc = lambda ele: self.evaluator_smear.evaluate("err_rho", ele.eta+ele.deltaEtaSC, ele.r9)
+            # Note: scale corrections have to be taken from the scale module for "standard" corrections (?); see below.
+        elif varlist == ['syst', 'pt', 'r9', 'AbsScEta'] and self.EtDependent :# 2022 ET-dependent
+            self.getSmear    = lambda ele: self.evaluator_smear.evaluate("smear",  ele.pt, ele.r9, abs(ele.eta+ele.deltaEtaSC))
+            self.getSmearUnc = lambda ele: self.evaluator_smear.evaluate("esmear", ele.pt, ele.r9, abs(ele.eta+ele.deltaEtaSC))
+            self.getScaleUnc = lambda ele: self.evaluator_smear.evaluate("escale", ele.pt, ele.r9, abs(ele.eta+ele.deltaEtaSC))
+        elif varlist == ['syst', 'pt', 'r9', 'ScEta'] and self.EtDependent :# 2024 ET-dependent
+            self.getSmear    = lambda ele: self.evaluator_smear.evaluate("smear",  ele.pt, ele.r9, ele.eta+ele.deltaEtaSC)
+            self.getSmearUnc = lambda ele: self.evaluator_smear.evaluate("esmear", ele.pt, ele.r9, ele.eta+ele.deltaEtaSC)
+            self.getScaleUnc = lambda ele: self.evaluator_smear.evaluate("escale", ele.pt, ele.r9, ele.eta+ele.deltaEtaSC)
+        else :
+            raise ValueError(f"ERROR: eleScaleRes: unexpected inputs for key={smearKey} and EtDependent={self.EtDependent}: {varlist}")
+
+        varlist = [i.name for i in self.evaluator_scale.inputs]        
+        if varlist ==  ['valtype', 'gain', 'run', 'eta', 'r9', 'et'] and not self.EtDependent : # 2022-2023 standard
+            self.getScale    = lambda event,ele: self.evaluator_scale.evaluate("total_correction",  ele.seedGain, float(event.run), ele.eta+ele.deltaEtaSC, ele.r9, ele.pt)
+            self.getScaleUnc = lambda ele: self.evaluator_scale.evaluate("total_uncertainty", ele.seedGain, 1., ele.eta+ele.deltaEtaSC, ele.r9, ele.pt) # Note: Run is always 1 in MC
+        elif varlist ==  ['syst', 'run', 'ScEta', 'r9', 'AbsScEta', 'pt', 'seedGain'] and self.EtDependent : # 2022-2023 ET-dependent
+            self.getScale    = lambda event,ele : self.evaluator_scale.evaluate("scale",  float(event.run), ele.eta+ele.deltaEtaSC, ele.r9, abs(ele.eta+ele.deltaEtaSC), ele.pt, float(ele.seedGain))
+        elif varlist ==  ['syst', 'run', 'ScEta', 'r9', 'pt', 'seedGain'] and self.EtDependent : # 2024 ET-dependent
+            self.getScale    = lambda event,ele : self.evaluator_scale.evaluate("scale",  float(event.run), ele.eta+ele.deltaEtaSC, ele.r9, ele.pt, float(ele.seedGain))
+            
+        else :
+            raise ValueError(f"ERROR: eleScaleRes: unexpected inputs for key={scaleKey} and EtDependent={self.EtDependent}: : {varlist}")
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
@@ -65,39 +99,28 @@ class eleScaleRes(Module):
         pt_scale_dn = []
         
         for ele in electrons:
-            if self.is_mc :
+            if self.is_mc : # smearing and uncertainties for MC
                 # Set up a deterministic random seed.
                 # The seed is unique by event and electron.
                 # A fixed entropy value is also included to decorrelate different modules doing similar things.
                 rng = np.random.default_rng(seed=np.random.SeedSequence([event.luminosityBlock, event.event, int(abs((ele.phi/pi)%1)*1e12), 5402201385]))
+                rnd = rng.normal(loc=0., scale=1) # The same random number should be used for central value and up/down variation
 
-                if self.EtDependent:
-                    rho = self.evaluator_smear.evaluate("smear", ele.pt, ele.r9, abs(ele.eta))
-                else:
-                    rho = self.evaluator_smear.evaluate("rho", ele.eta, ele.r9)
-                smearing = rng.normal(loc=1., scale=rho)
-                pt_corr.append(smearing * ele.pt)
+                smear = self.getSmear(ele)
+                smeared_pt = ele.pt*(1.+smear*rnd)
+                pt_corr.append(smeared_pt)
 
-                if self.EtDependent:
-                    unc_rho = self.evaluator_smear.evaluate("esmear", ele.pt, ele.r9, abs(ele.eta))
-                else:
-                    unc_rho = self.evaluator_smear.evaluate("err_rho", ele.eta, ele.r9)
-                smearing_up = rng.normal(loc=1., scale=rho + unc_rho)
-                smearing_dn = rng.normal(loc=1., scale=rho - unc_rho)
-                pt_smear_up.append(smearing_up * ele.pt)
-                pt_smear_dn.append(smearing_dn * ele.pt)
+                unc_smear = self.getSmearUnc(ele)
+                pt_smear_up.append(ele.pt*(1.+(smear+unc_smear)*rnd))
+                pt_smear_dn.append(ele.pt*(1.+max(0.,smear-unc_smear)*rnd))
 
-                if self.EtDependent :
-                    scale_MC_unc = self.evaluator_scale.evaluate("escale", float(event.run), ele.eta, ele.r9, abs(ele.eta), ele.pt, float(ele.seedGain))
-                else:
-                    scale_MC_unc = self.evaluator_scale.evaluate("total_uncertainty", ele.seedGain, float(event.run), ele.eta, ele.r9, ele.pt)
-                pt_scale_up.append((1+scale_MC_unc) * ele.pt)
-                pt_scale_dn.append((1-scale_MC_unc) * ele.pt)
-            else :
-                if self.EtDependent :
-                    scale = self.evaluator_scale.evaluate("scale", float(event.run), ele.eta, ele.r9, abs(ele.eta), ele.pt, float(ele.seedGain))
-                else:
-                    scale = self.evaluator_scale.evaluate("total_correction", ele.seedGain, float(event.run), ele.eta, ele.r9, ele.pt)
+                # Scale uncertainty is evaluated from original variables, but applied to the smeared pT.
+                scale_MC_unc = self.getScaleUnc(ele)
+                pt_scale_up.append((1+scale_MC_unc) * smeared_pt)
+                pt_scale_dn.append((1-scale_MC_unc) * smeared_pt)
+                
+            else : # Scale correction for data
+                scale = self.getScale(event, ele)
                 pt_corr.append(scale * ele.pt)
 
         if self.overwritePt :

--- a/test/example_electronSF.py
+++ b/test/example_electronSF.py
@@ -13,7 +13,7 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import Pos
 from PhysicsTools.NATModules.modules.electronSF import *
 
 # Set up the muon correction module
-eleSF = ElectronSF("/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2016postVFP_UL/electron.json.gz")
+eleSF = ElectronSF("/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run2-2016postVFP-UL-NanoAODv9/2024-07-02/electron.json.gz")
 set = 'UL-Electron-ID-SF'
 era = '2016postVFP'
 

--- a/test/example_electronSS.py
+++ b/test/example_electronSS.py
@@ -8,15 +8,15 @@ EtDependent = True
 
 # Set up the Electron correction module, for 2022EE MC
 if EtDependent:
-  json_path = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2022_Summer22EE/electronSS_EtDependent.json.gz"
+  json_path = "/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-04-15/electronSS_EtDependent.json.gz"
   scaleKey = "EGMScale_Compound_Ele_2022postEE"
   smearKey = "EGMSmearAndSyst_ElePTsplit_2022postEE"
 else:
-  json_path = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2022_Summer22EE/electronSS.json.gz"
+  json_path = "/cvmfs/cms-griddata.cern.ch/cat/metadata/EGM/Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-04-15/electronSS.json.gz"
   scaleKey = "Scale"
   smearKey = "Smearing" 
 
-eleSS = eleScaleRes(json_path, scaleKey, smearKey, True, EtDependent)
+eleSS = eleScaleRes(json_path, scaleKey, smearKey, True)
 # Settings for post-processor
 from argparse import ArgumentParser
 parser = ArgumentParser(description="Process nanoAOD files and add branches",epilog="Good luck!")

--- a/test/example_jetId.py
+++ b/test/example_jetId.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""This is an example of configuring and using the module for deriving the jetId variable."""
+"""This is an example of configuring and using the module to derive the jetId variable."""
 
 from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import PostProcessor
 from PhysicsTools.NATModules.modules.jetId import jetId
 
-json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2024_Winter24/jetid.json.gz"
+json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-07-17/jetid.json.gz"
 
 jetId = jetId(json, jetType="AK4PUPPI")
 

--- a/test/example_jetVeto.py
+++ b/test/example_jetVeto.py
@@ -4,7 +4,7 @@
 from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import PostProcessor
 from PhysicsTools.NATModules.modules.jetVetoMap import jetVMAP
 
-json_JVMAP = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22/jetvetomaps.json.gz"
+json_JVMAP = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/2025-09-23/jetvetomaps.json.gz"
 corrName = "Summer22_23Sep2023_RunCD_V1"
 veto_map_name = "jetvetomap"
 

--- a/test/example_muonSF.py
+++ b/test/example_muonSF.py
@@ -14,8 +14,7 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import Pos
 from PhysicsTools.NATModules.modules.muonSF import *
 
 # Set up the muon correction module
-#muSF = MuonSF("/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2016postVFP_UL/muon_Z.json.gz") # 2016UL
-muSF = MuonSF("/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2022_Summer22EE/muon_Z.json.gz")
+muSF = MuonSF("/cvmfs/cms-griddata.cern.ch/cat/metadata/MUO/Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-08-14/muon_Z.json.gz")
 
 # Add Medium ID scale factor
 muSF.addCorrection('NUM_MediumID_DEN_TrackerMuons', 'nominal', "SF")
@@ -30,7 +29,6 @@ parser.add_argument('-m', '--maxevts', type=int, default=10000) # limit number o
 args = parser.parse_args()
 branchsel = None #"keepElectron.txt" # keep only Electron branches for speed
 fnames = args.infiles or [
-    #"root://cms-xrd-global.cern.ch//store/mc/RunIISummer20UL16NanoAODv9/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/20UL16JMENano_106X_mcRun2_asymptotic_v17-v1/2820000/11061525-9BB6-F441-9C12-4489135219B7.root" # 2016UL
     "root://cms-xrd-global.cern.ch//store/mc/Run3Summer22EENanoAODv12/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v6-v2/2540000/25c8f5ff-9de0-4a0c-9e2f-757332ad392f.root", # 2022EE
 
 ]

--- a/test/example_muonSS.py
+++ b/test/example_muonSS.py
@@ -6,9 +6,9 @@ from PhysicsTools.NATModules.modules.muonScaleRes import *
 
 # Set up the correction module.
 # json files are not included in the central cvmfs area at the time of release.
-# see https://gitlab.cern.ch/cms-muonPOG/muonscarekit/-/tree/master/corrections for details.
+# see https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/master/examples/muoScaleAndSmearingRDFExample.py for details.
 
-json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2022_Summer22EE/muon_scalesmearing.json.gz"
+json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/MUO/Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-08-14/muon_scalesmearing.json.gz"
 muSS = muonScaleRes(json, overwritePt=True, is_mc=True, minPt=3.)
 
 

--- a/test/example_puWeight.py
+++ b/test/example_puWeight.py
@@ -12,7 +12,7 @@ ROOT.PyConfig.IgnoreCommandLineOptions = True
 
 # Set up the PU reweighting module, 2022EE
 from PhysicsTools.NATModules.modules.puWeightProducer import puWeightProducer 
-puWeight = puWeightProducer(json="/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2022_Summer22EE/puWeights.json.gz", key="Collisions2022_359022_362760_eraEFG_GoldenJson")
+puWeight = puWeightProducer(json="/cvmfs/cms-griddata.cern.ch/cat/metadata/LUM/Run3-22EFGSep23-Summer22EE-NanoAODv12/2024-01-31/puWeights.json.gz", key="Collisions2022_359022_362760_eraEFG_GoldenJson")
 
 
 # Settings for post-processor


### PR DESCRIPTION
update electron scale/smearing module to:
- support 2024 corrections, which use a different set of variables. 
- The variables to be passed are now automatically detected from the correctionlib objects specified by `scaleKey `and `smearKey`. Hence, it is no longer necessary to specify if corrrections are "standard" or  "Et-dependent" and the corresponding variable has been removed from the constructor.
- correct a few small bugs:
   - supercluster eta is now used everywhere, instead than the electron eta [cf. [here](https://cms-talk.web.cern.ch/t/2022-and-2023-scale-and-smearing-corrections/110765/4?u=amapane)] 
   - the same random number should be used for smearing and systematic variation [cf. [egamma example](https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/3b0d19b8bc92731fbe8c5debf45e3d8ba16a1b3c/examples/egmScaleAndSmearingExample.py)]. The previous implementation was drawing different random numbers for each one, which adds additional statistical fluctuation to up and down variations
   - The scale uncertainty should be obtained from the smearing correction set for Et-dependent corrections, not from the scale one [see [here](https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/3b0d19b8bc92731fbe8c5debf45e3d8ba16a1b3c/examples/egmScaleAndSmearingExample.py#L123)]
   - The scale uncertainty must be applied to the smeared pT, not to the original one [see [here](https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/3b0d19b8bc92731fbe8c5debf45e3d8ba16a1b3c/examples/egmScaleAndSmearingExample.py#L122)]

In addition, examples have been updated to point to the new correction area, `/cvmfs/cms-griddata.cern.ch/cat/metadata/`.