### PR TITLE
Implement JME recommendation, Freeze L2L3Residual for 2024 only

### DIFF
--- a/python/modules/jetCorr.py
+++ b/python/modules/jetCorr.py
@@ -17,9 +17,10 @@ import numpy as np
 import correctionlib
 
 class jetJERC(Module):
-    def __init__(self, json_JERC, json_JERsmear, L1Key=None, L2Key=None, L3Key=None, L2L3Key=None, scaleKey=None, smearKey=None, JERKey=None, JERsfKey=None, overwritePt=False, usePhiDependentJEC=False, useRunDependentJEC=False):
+    def __init__(self, era, json_JERC, json_JERsmear, L1Key=None, L2Key=None, L3Key=None, L2L3Key=None, scaleKey=None, smearKey=None, JERKey=None, JERsfKey=None, overwritePt=False, usePhiDependentJEC=False, useRunDependentJEC=False):
         """Correct jets following recommendations of JME POG.
         Parameters:
+            era: year definition
             json_JERC: full path of json file with JERC corrections
             json_JERsmear: full path of json file with smearing terms for JER
             L1Key: key for L1 corrections
@@ -31,7 +32,10 @@ class jetJERC(Module):
             JERKey: key for JER (None for Data)
             JERsfKey: key for JER scale factor (None for Data)
             overwritePt: replace value in the pt branch, and store the old one as "uncorrected_pt"
+            usePhiDependentJEC: Flag for Phi-dependent JEC, True in 2023postBPix and afterwards
+            useRunDependentJEC: Flag for Run-dependent JEC, True only in 2023 data (not MC)
         """
+        self.era = era
         self.overwritePt = overwritePt
         self.usePhiDependentJEC = usePhiDependentJEC
         self.useRunDependentJEC = useRunDependentJEC
@@ -154,9 +158,19 @@ class jetJERC(Module):
             pt_L3 = pt_L2 * self.evaluator_L3.evaluate(jet.eta, pt_L2)
 
             if self.useRunDependentJEC:
-                pt_JEC = pt_L3 * self.evaluator_L2L3.evaluate(float(event.run), jet.eta, pt_L3)
+                if pt_L3 < 30.0 and 2.0 < abs(jet.eta) < 2.5 and self.era == 2024:
+                    # JME recommendation (2024 only): Freeze L2L3Residual at pT = 30 GeV for pt < 30 GeV in 2.0 < |eta| < 2.5
+                    resL2L3_pT30 = self.evaluator_L2L3.evaluate(float(event.run), jet.eta, 30.0)
+                    pt_JEC = pt_L3 * resL2L3_pT30
+                else:
+                    pt_JEC = pt_L3 * self.evaluator_L2L3.evaluate(float(event.run), jet.eta, pt_L3)
             else:
-                pt_JEC = pt_L3 * self.evaluator_L2L3.evaluate(jet.eta, pt_L3)
+                if pt_L3 < 30.0 and 2.0 < abs(jet.eta) < 2.5 and self.era == 2024:
+                    # JME recommendation (2024 only): Freeze L2L3Residual at pT = 30 GeV for pt < 30 GeV in 2.0 < |eta| < 2.5
+                    resL2L3_pT30 = self.evaluator_L2L3.evaluate(jet.eta, 30.0)
+                    pt_JEC = pt_L3 * resL2L3_pT30
+                else:
+                    pt_JEC = pt_L3 * self.evaluator_L2L3.evaluate(jet.eta, pt_L3)
 
             JEC = pt_JEC / pt_raw
             mass_JEC = mass_raw * JEC

--- a/test/example_jetCorr.py
+++ b/test/example_jetCorr.py
@@ -6,6 +6,7 @@ from PhysicsTools.NATModules.modules.jetCorr import jetJERC
 
 json_JERC = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/2025-09-23/jet_jerc.json.gz"
 json_JERsmear = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/jer_smear.json.gz"
+era=2022
 
 jes_systematics_11split = [
         "Regrouped_Absolute",
@@ -36,7 +37,7 @@ useRunDependentJEC = False
 useJesSplittingScheme11 = False
 scaleKey = scaleKeyRegrouped11 if useJesSplittingScheme11 else scaleTotalKey
 
-jetCorrected = jetJERC(json_JERC, json_JERsmear, L1Key, L2Key, L3Key, L2L3Key, scaleKey, smearKey, JERKey, JERsfKey, overwritePt, usePhiDependentJEC, useRunDependentJEC)
+jetCorrected = jetJERC(era, json_JERC, json_JERsmear, L1Key, L2Key, L3Key, L2L3Key, scaleKey, smearKey, JERKey, JERsfKey, overwritePt, usePhiDependentJEC, useRunDependentJEC)
 
 # Settings for post-processor
 from argparse import ArgumentParser


### PR DESCRIPTION
This PR implements the JME recommendation for **2024 Data/MC** agreement in **2.0 < |eta| < 2.5.**
In this region, the L2L3Residual correction is frozen at pT = 30 GeV for jets with pT < 30 GeV, following the corresponding JME recommendation ([see slide 14 from JME presentation](https://indico.cern.ch/event/1615783/contributions/6811120/attachments/3186812/5672346/20251204_JetMET_PerformanceRun3.pdf))