### PR TITLE
Updates on b-tagging module to allow different options of b-tagging SF uncertainties

### DIFF
--- a/python/modules/jetBtag.py
+++ b/python/modules/jetBtag.py
@@ -9,7 +9,32 @@ class jetBtag(Module):
 
     def __init__(self, is_mc, tagger, tagger_name, WP, json_SF, json_eff, uncKey=None):
         """
-        Module to determine if jets are b-tagged and compute b-tagging SFs."""
+        Module to determine if jets are b-tagged and compute b-tagging SFs. Following BTV recommendations.
+        Explanation of the parameters:
+       
+        - is_mc is self-explanary: True or False.
+        
+        - tagger is the tagger name as part of the key in the b-tagging SF json.gz. Options are: "particleNet", "robustParticleTransformer" for NanoAODv12; "UParTAK4" for NanoAODv15. They are the key to obtain the working point, scale factor values, and systematic variations from the corresponding correctionlib json.gz. Check https://cms-analysis-corrections.docs.cern.ch/corrections/BTV/.
+        
+        - tagger_name describes the branches of the tagger score in NanoAOD. Basically, the branch will be Jet_{tagger_name}. Options are: "btagPNetB", "btagRobustParTAK4B" for NanoAODv12; "Jet_btagUParTAK4B" for NanoAODv15.
+        
+        - WP is the b-tagging working point. Options are "L", "M", "T", "XT", "XXT".
+        
+        - json_SF is the path to the json.gz of the b-tagging scale factors.
+        
+        - json_eff is the path to the json.gz of the b-tagging efficiency in simulation. It is required to apply b-tagging SF for untagged events. See https://btv-wiki.docs.cern.ch/PerformanceCalibration/fixedWPSFRecommendations/. This has to be computed individually based on the phase space of a certain analysis. Procedure to compute it:
+            - Take all simulated processes in the signal region.
+            - Apply all event-level weights properly.
+            - Collect all jets in them.
+            - Keep only jets passing jet ID and other jet selections applied.
+            - Compute the b-tagging efficiency in bins of pt, eta, for different hadron flavors (justified by NanoAOD branch Jet_hadronFlavour).
+            - Preferably compute at least separately for signal and background processes.
+
+        - uncKey is the (list of) systematic input key(s) to be included.
+            - If it is a list, a list of systematic variations namely [up_{key}, down_{key} for key in uncKey] will be computed.
+            - If it is a string, then up_{uncKey} and down_{uncKey} will be computed.
+            - If it is None, then total uncertainties are computed, i.e. up and down.
+        """
         self.tagger = tagger
         self.tagger_name = tagger_name
         self.is_mc = is_mc

--- a/python/modules/jetBtag.py
+++ b/python/modules/jetBtag.py
@@ -7,7 +7,7 @@ from math import pi
 
 class jetBtag(Module):
 
-    def __init__(self, is_mc, tagger, tagger_name, WP, uncKey, json_SF, json_eff):
+    def __init__(self, is_mc, tagger, tagger_name, WP, json_SF, json_eff, uncKey=None):
         """
         Module to determine if jets are b-tagged and compute b-tagging SFs."""
         self.tagger = tagger
@@ -28,7 +28,7 @@ class jetBtag(Module):
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
-        self.out.branch("Jet_isBtagged", "b", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger" % self.tagger)
+        self.out.branch("Jet_isBtagged", "O", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger" % self.tagger)
         
         if self.is_mc:
             self.out.branch("Jet_btagSF", "F", lenVar="nJet", title="B-tagging scale factor for the jet")

--- a/python/modules/jetBtag.py
+++ b/python/modules/jetBtag.py
@@ -7,12 +7,13 @@ from math import pi
 
 class jetBtag(Module):
 
-    def __init__(self, is_mc, tagger, tagger_name, WP, json_SF, json_eff):
+    def __init__(self, is_mc, tagger, tagger_name, WP, uncKey, json_SF, json_eff):
         """
         Module to determine if jets are b-tagged and compute b-tagging SFs."""
         self.tagger = tagger
         self.tagger_name = tagger_name
         self.is_mc = is_mc
+        self.uncKey = uncKey
         self.WP_name = WP
 
         evaluator = correctionlib.CorrectionSet.from_file(json_SF)
@@ -31,16 +32,23 @@ class jetBtag(Module):
         
         if self.is_mc:
             self.out.branch("Jet_btagSF", "F", lenVar="nJet", title="B-tagging scale factor for the jet")
-            self.out.branch("Jet_btagSF_up_correlated", "F", lenVar="nJet", title="B-tagging scale factor for the jet, up variation, correlated across years")
-            self.out.branch("Jet_btagSF_down_correlated", "F", lenVar="nJet", title="B-tagging scale factor for the jet, down variation, correlated across years")
-            self.out.branch("Jet_btagSF_up_uncorrelated", "F", lenVar="nJet", title="B-tagging scale factor for the jet, up variation, uncorrelated across years")
-            self.out.branch("Jet_btagSF_down_uncorrelated", "F", lenVar="nJet", title="B-tagging scale factor for the jet, down variation, uncorrelated across years")
-            
             self.out.branch("Jet_isBtaggedwithSF", "O", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger, after applying SF" % self.tagger)
-            self.out.branch("Jet_isBtaggedwithSF_up_correlated", "O", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger, after applying SF up variation, correlated across years" % self.tagger)
-            self.out.branch("Jet_isBtaggedwithSF_down_correlated", "O", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger, after applying SF down variation, correlated across years" % self.tagger)
-            self.out.branch("Jet_isBtaggedwithSF_up_uncorrelated", "O", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger, after applying SF up variation, uncorrelated across years" % self.tagger)
-            self.out.branch("Jet_isBtaggedwithSF_down_uncorrelated", "O", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger, after applying SF down variation, uncorrelated across years" % self.tagger)
+            if self.uncKey and isinstance(self.uncKey, list):
+                for label in self.uncKey:
+                    self.out.branch(f"Jet_{label}Up_btagSF", "F", lenVar="nJet", title="B-tagging scale factor for the jet, up variation, %s" % label)
+                    self.out.branch(f"Jet_{label}Dn_btagSF", "F", lenVar="nJet", title="B-tagging scale factor for the jet, down variation, %s" % label)
+                    self.out.branch(f"Jet_{label}Up_isBtaggedwithSF", "O", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger, after applying SF up variation, %s" % (self.tagger, label))
+                    self.out.branch(f"Jet_{label}Dn_isBtaggedwithSF", "O", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger, after applying SF down variation, %s" % (self.tagger, label))
+            elif self.uncKey:
+                self.out.branch(f"Jet_{self.uncKey}Up_btagSF", "F", lenVar="nJet", title="B-tagging scale factor for the jet, up variation, %s" % self.uncKey)
+                self.out.branch(f"Jet_{self.uncKey}Dn_btagSF", "F", lenVar="nJet", title="B-tagging scale factor for the jet, down variation, %s" % self.uncKey)
+                self.out.branch(f"Jet_{self.uncKey}Up_isBtaggedwithSF", "O", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger, after applying SF up variation, %s" % (self.tagger, self.uncKey))
+                self.out.branch(f"Jet_{self.uncKey}Dn_isBtaggedwithSF", "O", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger, after applying SF down variation, %s" % (self.tagger, self.uncKey))
+            else:
+                self.out.branch(f"Jet_Up_btagSF", "F", lenVar="nJet", title="B-tagging scale factor for the jet, up variation")
+                self.out.branch(f"Jet_Dn_btagSF", "F", lenVar="nJet", title="B-tagging scale factor for the jet, down variation")
+                self.out.branch(f"Jet_Up_isBtaggedwithSF", "O", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger, after applying SF up variation" % (self.tagger))
+                self.out.branch(f"Jet_Dn_isBtaggedwithSF", "O", lenVar="nJet", title="Whether the jet is b-tagged according to the %s tagger, after applying SF down variation" % (self.tagger))
 
     def analyze(self, event):
         jets = Collection(event, "Jet")
@@ -48,16 +56,18 @@ class jetBtag(Module):
         isBtagged = array('B', event.nJet*[0])
         if self.is_mc:
             btagSF = array('f', event.nJet*[1.0])
-            btagSF_up_correlated = array('f', event.nJet*[1.0])
-            btagSF_down_correlated = array('f', event.nJet*[1.0])
-            btagSF_up_uncorrelated = array('f', event.nJet*[1.0])
-            btagSF_down_uncorrelated = array('f', event.nJet*[1.0])
-
             isBtaggedWithSF = array('B', event.nJet*[0])
-            isBtaggedWithSF_up_correlated = array('B', event.nJet*[0])
-            isBtaggedWithSF_down_correlated = array('B', event.nJet*[0])
-            isBtaggedWithSF_up_uncorrelated = array('B', event.nJet*[0])
-            isBtaggedWithSF_down_uncorrelated = array('B', event.nJet*[0])
+
+            if self.uncKey and isinstance(self.uncKey, list):
+                btagSFUp = {label: array('f', event.nJet*[1.0]) for label in self.uncKey}
+                btagSFDn = {label: array('f', event.nJet*[1.0]) for label in self.uncKey}
+                isBtaggedWithSFUp = {label: array('B', event.nJet*[0]) for label in self.uncKey}
+                isBtaggedWithSFDn = {label: array('B', event.nJet*[0]) for label in self.uncKey}
+            else:
+                btagSFUp = array('f', event.nJet*[1.0])
+                btagSFDn = array('f', event.nJet*[1.0])
+                isBtaggedWithSFUp = array('B', event.nJet*[0])
+                isBtaggedWithSFDn = array('B', event.nJet*[0])
 
         for ijet, jet in enumerate(jets):
             isBtagged[ijet] = getattr(jet, self.tagger_name) > self.WP
@@ -71,42 +81,53 @@ class jetBtag(Module):
 
             sfEvaluator = self.evaluator_SF if abs(flavor) in [4, 5] else self.evaluator_SF_light
             isBtaggedWithSF[ijet] = isBtagged[ijet]
-            isBtaggedWithSF_up_correlated[ijet] = isBtagged[ijet]
-            isBtaggedWithSF_down_correlated[ijet] = isBtagged[ijet]
-            isBtaggedWithSF_up_uncorrelated[ijet] = isBtagged[ijet]
-            isBtaggedWithSF_down_uncorrelated[ijet] = isBtagged[ijet]
+            if self.uncKey and isinstance(self.uncKey, list):
+                for label in self.uncKey:
+                    isBtaggedWithSFUp[label][ijet] = isBtagged[ijet]
+                    isBtaggedWithSFDn[label][ijet] = isBtagged[ijet]
+            else:
+                isBtaggedWithSFUp[ijet] = isBtagged[ijet]
+                isBtaggedWithSFDn[ijet] = isBtagged[ijet]
 
             try:
                 btagSF[ijet] = sfEvaluator.evaluate("central", self.WP_name, flavor, abseta, pt)
-                btagSF_up_correlated[ijet] = sfEvaluator.evaluate("up_correlated", self.WP_name, flavor, abseta, pt)
-                btagSF_down_correlated[ijet] = sfEvaluator.evaluate("down_correlated", self.WP_name, flavor, abseta, pt)
-                btagSF_up_uncorrelated[ijet] = sfEvaluator.evaluate("up_uncorrelated", self.WP_name, flavor, abseta, pt)
-                btagSF_down_uncorrelated[ijet] = sfEvaluator.evaluate("down_uncorrelated", self.WP_name, flavor, abseta, pt)
+                if self.uncKey and isinstance(self.uncKey, list):
+                    for label in self.uncKey:
+                        btagSFUp[label][ijet] = sfEvaluator.evaluate("up_%s" % label, self.WP_name, flavor, abseta, pt)
+                        btagSFDn[label][ijet] = sfEvaluator.evaluate("down_%s" % label, self.WP_name, flavor, abseta, pt)
+                elif self.uncKey:
+                    btagSFUp[ijet] = sfEvaluator.evaluate("up_%s" % self.uncKey, self.WP_name, flavor, abseta, pt)
+                    btagSFDn[ijet] = sfEvaluator.evaluate("down_%s" % self.uncKey, self.WP_name, flavor, abseta, pt)
+                else:
+                    btagSFUp[ijet] = sfEvaluator.evaluate("up", self.WP_name, flavor, abseta, pt)
+                    btagSFDn[ijet] = sfEvaluator.evaluate("down", self.WP_name, flavor, abseta, pt)
+
                 btagEff = self.evaluator_eff.evaluate(flavorToLabel(flavor), pt, abseta)
+
             except Exception:
                 continue
 
             random = makeRandomValue(event, jet)
 
             isBtaggedWithSF[ijet] = applySF(isBtagged[ijet], btagSF[ijet], btagEff, random)
-            isBtaggedWithSF_up_correlated[ijet] = applySF(isBtagged[ijet], btagSF_up_correlated[ijet], btagEff, random)
-            isBtaggedWithSF_down_correlated[ijet] = applySF(isBtagged[ijet], btagSF_down_correlated[ijet], btagEff, random)
-            isBtaggedWithSF_up_uncorrelated[ijet] = applySF(isBtagged[ijet], btagSF_up_uncorrelated[ijet], btagEff, random)
-            isBtaggedWithSF_down_uncorrelated[ijet] = applySF(isBtagged[ijet], btagSF_down_uncorrelated[ijet], btagEff, random)
+            if self.uncKey and isinstance(self.uncKey, list):
+                for label in self.uncKey:
+                    isBtaggedWithSFUp[label][ijet] = applySF(isBtagged[ijet], btagSFUp[label][ijet], btagEff, random)
+                    isBtaggedWithSFDn[label][ijet] = applySF(isBtagged[ijet], btagSFDn[label][ijet], btagEff, random)
+            else:
+                isBtaggedWithSFUp[ijet] = applySF(isBtagged[ijet], btagSFUp[ijet], btagEff, random)
+                isBtaggedWithSFDn[ijet] = applySF(isBtagged[ijet], btagSFDn[ijet], btagEff, random)
 
         self.out.fillBranch("Jet_isBtagged", isBtagged)
         if self.is_mc:
             self.out.fillBranch("Jet_btagSF", btagSF)
-            self.out.fillBranch("Jet_btagSF_up_correlated", btagSF_up_correlated)
-            self.out.fillBranch("Jet_btagSF_down_correlated", btagSF_down_correlated)
-            self.out.fillBranch("Jet_btagSF_up_uncorrelated", btagSF_up_uncorrelated)
-            self.out.fillBranch("Jet_btagSF_down_uncorrelated", btagSF_down_uncorrelated)
-
             self.out.fillBranch("Jet_isBtaggedwithSF", isBtaggedWithSF)
-            self.out.fillBranch("Jet_isBtaggedwithSF_up_correlated", isBtaggedWithSF_up_correlated)
-            self.out.fillBranch("Jet_isBtaggedwithSF_down_correlated", isBtaggedWithSF_down_correlated)
-            self.out.fillBranch("Jet_isBtaggedwithSF_up_uncorrelated", isBtaggedWithSF_up_uncorrelated)
-            self.out.fillBranch("Jet_isBtaggedwithSF_down_uncorrelated", isBtaggedWithSF_down_uncorrelated)
+            if self.uncKey and isinstance(self.uncKey, list):
+                for label in self.uncKey:
+                    self.out.fillBranch(f"Jet_{label}Up_btagSF", btagSFUp[label])
+                    self.out.fillBranch(f"Jet_{label}Dn_btagSF", btagSFDn[label])
+                    self.out.fillBranch(f"Jet_{label}Up_isBtaggedwithSF", isBtaggedWithSFUp[label])
+                    self.out.fillBranch(f"Jet_{label}Dn_isBtaggedwithSF", isBtaggedWithSFDn[label])
 
         return True
 

--- a/test/example_jetBtag.py
+++ b/test/example_jetBtag.py
@@ -26,9 +26,9 @@ jet_btag = jetBtag(
     tagger=tagger,
     tagger_name=tagger_name,
     WP=WP,
-    uncKey=["correlated", "uncorrelated"],
     json_SF=json_SF,
     json_eff=json_eff,
+    uncKey=["correlated", "uncorrelated"],
 )
 
 branchsel = None

--- a/test/example_jetBtag.py
+++ b/test/example_jetBtag.py
@@ -12,7 +12,7 @@ tagger = "particleNet"
 tagger_name = "btagPNetB"
 WP = "M"
 is_mc = True
-json_SF = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/BTV/2022_Summer22EE/btagging.json.gz"
+json_SF = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-08-20/btagging.json.gz"
 json_eff = os.path.join(os.path.dirname(__file__), "btag_2022EE.json.gz")
 
 

--- a/test/example_jetBtag.py
+++ b/test/example_jetBtag.py
@@ -26,6 +26,7 @@ jet_btag = jetBtag(
     tagger=tagger,
     tagger_name=tagger_name,
     WP=WP,
+    uncKey=["correlated", "uncorrelated"],
     json_SF=json_SF,
     json_eff=json_eff,
 )


### PR DESCRIPTION
Dear Experts,

An input `uncKey` is given, such that:
- if `uncKey` is a list, e.g. `["correlated", "uncorrelated"]`, the jet b-tagging variations are computed and saved for each key in the list.
- if `uncKey` is not a list, it specify a single source / key to be computed and saved.
- if `uncKey` is `None`, then the total variation is computed.

Yours Sincerely,
Glenn