### PR TITLE
Handle jetId update recipe for nano v12

### DIFF
--- a/python/modules/jetId.py
+++ b/python/modules/jetId.py
@@ -1,5 +1,5 @@
 """
-Add jetId variable, following the example in https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/master/examples/jetidExample.py .
+Add or update Jet_jetId variable, following the JME recipes.
 See example in test/example_jetId.py for usage.
 """
 from __future__ import print_function
@@ -11,54 +11,85 @@ import correctionlib
 from array import array
 
 class jetId(Module):
-    def __init__(self, json,  jetType="AK4PUPPI"):
-        """Module to determine jetID variables (passTight, passTightLepVeto), 
-        packed in Jet_jetId as in nanoAODv12
+    def __init__(self, json,  nanoVersion=15):
+        """Module to fill/update jetID variables (passTight, passTightLepVeto), packed in Jet_jetId.
         Parameters:
-        - json: jetID json file
-        - jetType: "AK4PUPPI" or "AK4CHS"
+        - json: jetID json file (relevant only for nanoVersion>9)
+        - nanoVersion: determines the type of update: 
+          9   = no correction (https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVUL#NanoAODv9)
+          12  = update existing jetId according to recipe at https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13p6TeV#Jet_ID_implementation_with_NanoA
+          >12 = compute using JME correctionlib json as per https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/master/examples/jetidExample.py
         """
-        self.evaluator = correctionlib.CorrectionSet.from_file(json)
-        self.key_tight = f"{jetType}_Tight"
-        self.key_tightLeptonVeto = f"{jetType}_TightLeptonVeto"
+        self.nanoVersion=nanoVersion
+        if self.nanoVersion > 12:
+            jetType="AK4PUPPI" # Note: Jet type is "AK4CHS" only for nano v9, which requires no correction
+            self.evaluator = correctionlib.CorrectionSet.from_file(json)
+            self.key_tight = f"{jetType}_Tight"
+            self.key_tightLeptonVeto = f"{jetType}_TightLeptonVeto"
         
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
-        self.out.branch("Jet_jetId", "b", lenVar="nJet", title="Jet ID flag: bit2 is tight, bit3 is tightLepVeto (recomputed using JSON)") # Save as UChar_t as it was up to nanoAODv14
+        if self.nanoVersion > 9 :
+            docstr = "(recomputed using JSON)" if self.nanoVersion > 12 else "(updated according to nanoAODv12 recipe)"
+            self.out.branch("Jet_jetId", "b", lenVar="nJet", title=f"Jet ID flag: bit2 is tight, bit3 is tightLepVeto {docstr}") # Note: b=UChar_t
 
 
     def analyze(self, event):
+        if self.nanoVersion < 12 : return True # no correction needed
+        
         jets = Collection(event, "Jet")
-
         jet_Ids = array('B', event.nJet*[0]) # Note: UChar_t is uppercase 'B' in python array
-        for ijet, jet in enumerate(jets):
-            multiplicity = jet.chMultiplicity + jet.neMultiplicity
 
-            passTight = self.evaluator[self.key_tight].evaluate(
-                jet.eta,
-                jet.chHEF,
-                jet.neHEF,
-                jet.chEmEF,
-                jet.neEmEF,
-                jet.muEF,
-                jet.chMultiplicity,
-                jet.neMultiplicity,
-                multiplicity
-            )
+        if self.nanoVersion == 12 : # Update existing jetId variable 
+            passTight = False
+            passTightLepVeto = False
+            for ijet, jet in enumerate(jets):
+                passTightOrig = bool(jet.jetId & (1 << 1))
+                # Jet-passJetIdTight based on eta conditions
+                if abs(jet.eta) <= 2.7:
+                    passTight = passTightOrig
+                elif 2.7 < abs(jet.eta) <= 3.0:
+                    passTight = passTightOrig and (jet.neHEF < 0.99)
+                elif abs(jet.eta) > 3.0:
+                    passTight = passTightOrig and (jet.neEmEF < 0.4)
 
-            passTightLepVeto = self.evaluator[self.key_tightLeptonVeto].evaluate(
-                jet.eta,
-                jet.chHEF,
-                jet.neHEF,
-                jet.chEmEF,
-                jet.neEmEF,
-                jet.muEF,
-                jet.chMultiplicity,
-                jet.neMultiplicity,
-                multiplicity
-            )
-            
-            jet_Ids[ijet] = int(passTight)*2 + int(passTightLepVeto)*4
+                # Jet-passJetIdTightLepVeto based on additional lepton veto conditions
+                if abs(jet.eta) <= 2.7:
+                    passTightLepVeto = passTight and (jet.muEF < 0.8) and (jet.chEmEF < 0.8)
+                else:
+                    passTightLepVeto = passTight
+
+                jet_Ids[ijet] = int(passTight)*2 + int(passTightLepVeto)*4
+
+        elif self.nanoVersion >= 13 : # jetId recomputed using correctionlib files
+            for ijet, jet in enumerate(jets):
+                multiplicity = jet.chMultiplicity + jet.neMultiplicity
+
+                passTight = self.evaluator[self.key_tight].evaluate(
+                    jet.eta,
+                    jet.chHEF,
+                    jet.neHEF,
+                    jet.chEmEF,
+                    jet.neEmEF,
+                    jet.muEF,
+                    jet.chMultiplicity,
+                    jet.neMultiplicity,
+                    multiplicity
+                )
+
+                passTightLepVeto = self.evaluator[self.key_tightLeptonVeto].evaluate(
+                    jet.eta,
+                    jet.chHEF,
+                    jet.neHEF,
+                    jet.chEmEF,
+                    jet.neEmEF,
+                    jet.muEF,
+                    jet.chMultiplicity,
+                    jet.neMultiplicity,
+                    multiplicity
+                )
+
+                jet_Ids[ijet] = int(passTight)*2 + int(passTightLepVeto)*4
 
         self.out.fillBranch("Jet_jetId", jet_Ids)
         return True

--- a/test/example_jetId.py
+++ b/test/example_jetId.py
@@ -4,9 +4,15 @@
 from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import PostProcessor
 from PhysicsTools.NATModules.modules.jetId import jetId
 
-json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-07-17/jetid.json.gz"
+testVersion = 15
 
-jetId = jetId(json, jetType="AK4PUPPI")
+if testVersion == 12 :
+    jetId = jetId(None, nanoVersion=12)
+    defaultFile = "root://cms-xrd-global.cern.ch//store/mc/Run3Summer22NanoAODv12/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_v5-v2/30000/542e888a-24b0-4e51-a494-d2690f894c0d.root"
+else:
+    json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-07-17/jetid.json.gz"
+    jetId = jetId(json, nanoVersion=15)
+    defaultFile = "root://cms-xrd-global.cern.ch//store/data/Run2024C/MuonEG/NANOAOD/MINIv6NANOv15-v1/2530000/694ee48f-c22e-4ae3-83f8-19f98edb481b.root"
 
 # Settings for post-processor
 from argparse import ArgumentParser
@@ -15,9 +21,7 @@ parser.add_argument('-i', '--infiles', nargs='+')
 parser.add_argument('-m', '--maxevts', type=int, default=10000) # limit number of events (per file) for testing
 args = parser.parse_args()
 branchsel = None
-fnames = args.infiles or [
-      "root://cms-xrd-global.cern.ch//store/data/Run2024C/MuonEG/NANOAOD/MINIv6NANOv15-v1/2530000/694ee48f-c22e-4ae3-83f8-19f98edb481b.root",
-]
+fnames = args.infiles or [defaultFile]
 
 # Process nanoAOD file
 p = PostProcessor(".", fnames, "nJet>0 && Jet_pt>30",


### PR DESCRIPTION
Update `jetId.py` to handle the different recipes for [Run2 ](https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVUL#Usage_with_NanoAOD)and [Run3](https://twiki.cern.ch/twiki/bin/view/CMS/JetID13p6TeV#Jet_ID_implementation_with_NanoA) depending on nanoAOD version:
- no update in v9
- update with suggested code for v12
- compute with correctionlib json for v13 onwards

The module now gets `nanoVersion `as a parameter. 
The `jetType` parameter is removed as the Jet collection is always `AK4PUPPI` in v12 onwards and `AK4CHS` in v9.

