### PR TITLE
Update JER SF unc treatment

### DIFF
--- a/python/modules/jetCorr.py
+++ b/python/modules/jetCorr.py
@@ -17,7 +17,7 @@ import numpy as np
 import correctionlib
 
 class jetJERC(Module):
-    def __init__(self, era, json_JERC, json_JERsmear, L1Key=None, L2Key=None, L3Key=None, L2L3Key=None, scaleKey=None, smearKey=None, JERKey=None, JERsfKey=None, overwritePt=False, usePhiDependentJEC=False, useRunDependentJEC=False):
+    def __init__(self, era, json_JERC, json_JERsmear, L1Key=None, L2Key=None, L3Key=None, L2L3Key=None, scaleKey=None, smearKey=None, JERKey=None, JERsfKey=None, JERsfUncKey=None, overwritePt=False, usePhiDependentJEC=False, useRunDependentJEC=False):
         """Correct jets following recommendations of JME POG.
         Parameters:
             era: year definition
@@ -31,6 +31,7 @@ class jetJERC(Module):
             smearKey: key for smearing formula (None for Data)
             JERKey: key for JER (None for Data)
             JERsfKey: key for JER scale factor (None for Data)
+            JERsfUncKey: key for JER scale factor uncertainty (None for Data)
             overwritePt: replace value in the pt branch, and store the old one as "uncorrected_pt"
             usePhiDependentJEC: Flag for Phi-dependent JEC, True in 2023postBPix and afterwards
             useRunDependentJEC: Flag for Run-dependent JEC, True only in 2023 data (not MC)
@@ -63,6 +64,10 @@ class jetJERC(Module):
             self.evaluator_JERsmear = self.evaluator_jer[smearKey]
             self.evaluator_JER = self.evaluator_JERC[JERKey]
             self.evaluator_JERsf = self.evaluator_JERC[JERsfKey]
+            if JERsfUncKey != None:
+                self.evaluator_JERsfUnc = self.evaluator_JERC[JERsfUncKey]
+            else:
+                self.evaluator_JERsfUnc = None
             if isinstance(self.scaleKey, list):
                 # Regrouped 11-source JES
                 self.evaluator_JES = {}
@@ -191,9 +196,15 @@ class jetJERC(Module):
                 pt_gen = np.where((np.abs(pt_JEC - gen_jets_pt) < 3 * pt_JEC * JER) & (np.sqrt(delta_eta**2 + delta_phi**2)<0.2), gen_jets_pt, -1.0)
                 pt_gen = pt_gen[pt_gen > 0][0] if np.any(pt_gen > 0) else -1. ## If no gen-matching, simply -1
 
-                JERsf = self.evaluator_JERsf.evaluate(jet.eta, jet.pt, "nom")
-                JERsf_up = self.evaluator_JERsf.evaluate(jet.eta, jet.pt, "up")
-                JERsf_dn = self.evaluator_JERsf.evaluate(jet.eta, jet.pt, "down")
+                ## For the version before 2026-06-05, JER SF uncertainties are given in the same key as the nominal SF, classified by the "up"/"down" variation parameter. For the version equal or after 2026-06-05, JER SF uncertainties are given in a separate key, and the SF evaluation is not classified by the variation parameter. The two implementations can be handled with an if statement on the presence of JERsfUncKey.
+                if self.evaluator_JERsfUnc != None:
+                    JERsf = self.evaluator_JERsf.evaluate(jet.eta, jet.pt)
+                    JERsf_up = JERsf * (1 + self.evaluator_JERsfUnc.evaluate(jet.eta, jet.pt))
+                    JERsf_dn = JERsf * (1 - self.evaluator_JERsfUnc.evaluate(jet.eta, jet.pt))
+                else:
+                    JERsf = self.evaluator_JERsf.evaluate(jet.eta, jet.pt, "nom")
+                    JERsf_up = self.evaluator_JERsf.evaluate(jet.eta, jet.pt, "up")
+                    JERsf_dn = self.evaluator_JERsf.evaluate(jet.eta, jet.pt, "down")
                 # FIXME: prevent error where event is outside the int32 range. cf: github.com/cms-nanoAOD/correctionlib/issues/298
                 JERsmear = self.evaluator_JERsmear.evaluate(pt_JEC, jet.eta, pt_gen, event.Rho_fixedGridRhoFastjetAll, int(event.event&0x7FFFFFFF), JER, JERsf)
                 JERsmear_up = self.evaluator_JERsmear.evaluate(pt_JEC, jet.eta, pt_gen, event.Rho_fixedGridRhoFastjetAll, int(event.event&0x7FFFFFFF), JER, JERsf_up)

--- a/test/example_jetCorr.py
+++ b/test/example_jetCorr.py
@@ -4,7 +4,7 @@
 from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import PostProcessor
 from PhysicsTools.NATModules.modules.jetCorr import jetJERC
 
-json_JERC = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/2025-09-23/jet_jerc.json.gz"
+json_JERC = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/2026-06-05/jet_jerc.json.gz"
 json_JERsmear = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/jer_smear.json.gz"
 era=2022
 
@@ -22,22 +22,23 @@ jes_systematics_11split = [
         "Regrouped_RelativeSample_{year}",
     ]
 
-L1Key = "Summer22_22Sep2023_V3_MC_L1FastJet_AK4PFPuppi"
-L2Key = "Summer22_22Sep2023_V3_MC_L2Relative_AK4PFPuppi"
-L3Key = "Summer22_22Sep2023_V3_MC_L3Absolute_AK4PFPuppi"
-L2L3Key = "Summer22_22Sep2023_V3_MC_L2L3Residual_AK4PFPuppi"
-scaleTotalKey = "Summer22_22Sep2023_V3_MC_Total_AK4PFPuppi"
-scaleKeyRegrouped11 = [f"Summer22_22Sep2023_V3_MC_{label.format(year='2022')}_AK4PFPuppi" for label in jes_systematics_11split] # 11-source JES uncertainties
+L1Key = "Summer22_22Sep2023_V4_MC_L1FastJet_AK4PFPuppi"
+L2Key = "Summer22_22Sep2023_V4_MC_L2Relative_AK4PFPuppi"
+L3Key = "Summer22_22Sep2023_V4_MC_L3Absolute_AK4PFPuppi"
+L2L3Key = "Summer22_22Sep2023_V4_MC_L2L3Residual_AK4PFPuppi"
+scaleTotalKey = "Summer22_22Sep2023_V4_MC_Total_AK4PFPuppi"
+scaleKeyRegrouped11 = [f"Summer22_22Sep2023_V4_MC_{label.format(year='2022')}_AK4PFPuppi" for label in jes_systematics_11split] # 11-source JES uncertainties
 smearKey = "JERSmear" # 1 Total source JES uncertainties
-JERKey = "Summer22_22Sep2023_JRV1_MC_PtResolution_AK4PFPuppi"
-JERsfKey = "Summer22_22Sep2023_JRV1_MC_ScaleFactor_AK4PFPuppi"
+JERKey = "Summer22_22Sep2023_JRV2_MC_PtResolution_AK4PFPuppi"
+JERsfKey = "Summer22_22Sep2023_JRV2_MC_ScaleFactor_AK4PFPuppi"
+JERsfUncKey = "Summer22_22Sep2023_JRV2_MC_SFUncertainty_AK4PFPuppi" 
 overwritePt = True
 usePhiDependentJEC = False
 useRunDependentJEC = False
 useJesSplittingScheme11 = False
 scaleKey = scaleKeyRegrouped11 if useJesSplittingScheme11 else scaleTotalKey
 
-jetCorrected = jetJERC(era, json_JERC, json_JERsmear, L1Key, L2Key, L3Key, L2L3Key, scaleKey, smearKey, JERKey, JERsfKey, overwritePt, usePhiDependentJEC, useRunDependentJEC)
+jetCorrected = jetJERC(era, json_JERC, json_JERsmear, L1Key, L2Key, L3Key, L2L3Key, scaleKey, smearKey, JERKey, JERsfKey, JERsfUncKey, overwritePt, usePhiDependentJEC, useRunDependentJEC)
 
 # Settings for post-processor
 from argparse import ArgumentParser


### PR DESCRIPTION
Dear Experts,

I updated the module `jetCorr` to be compatible with the recent JME updates [1,2], which separates the key for JER SF uncertainties `MC_SFUncertainty` from the key for JER SF `MC_ScaleFactor`. An additional input is required `JERsfUncKey`. 

Please notice that, in the case when jet-related systematics are computed while `JERsfUncKey` is `None`, the old method will be used. For the case when people are still using the old version of json.gz.

Yours Sincerely,
Geliang

[1] https://github.com/cms-jet/JRDatabase/pull/30
[2] https://cms-talk.web.cern.ch/t/new-jer-smearing-inputs-available-for-2024-and-2025/145723